### PR TITLE
UPS - Handle multiple packages

### DIFF
--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -891,6 +891,9 @@ module ActiveShipping
           location_from_address_node(first_shipment.at("#{location}/Address"))
         end
 
+        # Service code
+        service_code = first_shipment.xpath('Service/Code').text
+
         # Get status, tracking, etc for each package
         packages = first_shipment.xpath('Package').map do |package|
           # Tracking Number
@@ -992,6 +995,7 @@ module ActiveShipping
                            :origin => origin,
                            :destination => destination,
                            :packages => packages,
+                           :service_code => service_code,
                            # For legacy purposes, shipment level values default to first package values
                            :status => packages.first&.status,
                            :status_code => packages.first&.status_code,

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -893,7 +893,11 @@ module ActiveShipping
 
         # Get status, tracking, etc for each package
         packages = first_shipment.xpath('Package').map do |package|
+          # Tracking Number
           tracking_number = package.at('TrackingNumber').text
+
+          # Weight
+          weight_lbs = package.xpath('PackageWeight/Weight').text
 
           # Get the package status
           status_nodes = package.css('Activity > Status > StatusType')
@@ -974,7 +978,8 @@ module ActiveShipping
               :shipment_events => shipment_events,
               :origin => origin,
               :destination => destination,
-              :tracking_number => tracking_number
+              :tracking_number => tracking_number,
+              :weight_lbs => weight_lbs
             )
           end
         end
@@ -1275,7 +1280,7 @@ module ActiveShipping
                 :status,:status_code, :status_description,
                 :ship_time, :scheduled_delivery_date, :actual_delivery_date, :attempted_delivery_date,
                 :delivery_signature, :tracking_number, :shipment_events,
-                :shipper_address, :origin, :destination
+                :shipper_address, :origin, :destination, :weight_lbs
 
     def initialize(options)
       @carrier = options[:carrier].parameterize.to_sym
@@ -1293,6 +1298,7 @@ module ActiveShipping
       @shipper_address = options[:shipper_address]
       @origin = options[:origin]
       @destination = options[:destination]
+      @weight_lbs = options[:weight_lbs]
     end
 
     # The latest tracking event for this shipment, i.e. the current status.

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -997,13 +997,13 @@ module ActiveShipping
                            :packages => packages,
                            :service_code => service_code,
                            # For legacy purposes, shipment level values default to first package values
-                           :status => packages.first&.status,
-                           :status_code => packages.first&.status_code,
-                           :status_description => packages.first&.status_description,
-                           :delivery_signature => packages.first&.delivery_signature,
-                           :scheduled_delivery_date => packages.first&.scheduled_delivery_date,
-                           :actual_delivery_date => packages.first&.actual_delivery_date,
-                           :shipment_events => packages.first&.shipment_events)
+                           :status => packages&.first&.status,
+                           :status_code => packages&.first&.status_code,
+                           :status_description => packages&.first&.status_description,
+                           :delivery_signature => packages&.first&.delivery_signature,
+                           :scheduled_delivery_date => packages&.first&.scheduled_delivery_date,
+                           :actual_delivery_date => packages&.first&.actual_delivery_date,
+                           :shipment_events => packages&.first&.shipment_events)
     end
 
     def parse_delivery_dates_response(origin, destination, packages, response, options={})

--- a/lib/active_shipping/carriers/ups.rb
+++ b/lib/active_shipping/carriers/ups.rb
@@ -895,7 +895,7 @@ module ActiveShipping
         service_code = first_shipment.xpath('Service/Code').text
 
         # Get status, tracking, etc for each package
-        packages = first_shipment.xpath('Package').map do |package|
+        packages = xml.root.xpath('Shipment/Package').map do |package|
           # Tracking Number
           tracking_number = package.at('TrackingNumber').text
 

--- a/lib/active_shipping/tracking_response.rb
+++ b/lib/active_shipping/tracking_response.rb
@@ -50,8 +50,8 @@ module ActiveShipping
   # @!attribute destination
   #   @return [ActiveShipping::Location]
   class TrackingResponse < Response
-    attr_reader :carrier,:carrier_name,
-                :status,:status_code, :status_description,
+    attr_reader :carrier, :carrier_name, :service_code,
+                :status, :status_code, :status_description,
                 :ship_time, :scheduled_delivery_date, :actual_delivery_date, :attempted_delivery_date,
                 :delivery_signature, :tracking_number, :shipment_events,
                 :shipper_address, :origin, :destination, :packages
@@ -60,6 +60,7 @@ module ActiveShipping
     def initialize(success, message, params = {}, options = {})
       @carrier = options[:carrier].parameterize.to_sym
       @carrier_name = options[:carrier]
+      @service_code = options[:service_code]
       @status = options[:status]
       @status_code = options[:status_code]
       @status_description = options[:status_description]

--- a/lib/active_shipping/tracking_response.rb
+++ b/lib/active_shipping/tracking_response.rb
@@ -54,7 +54,7 @@ module ActiveShipping
                 :status,:status_code, :status_description,
                 :ship_time, :scheduled_delivery_date, :actual_delivery_date, :attempted_delivery_date,
                 :delivery_signature, :tracking_number, :shipment_events,
-                :shipper_address, :origin, :destination
+                :shipper_address, :origin, :destination, :packages
 
     # @params (see ActiveShipping::Response#initialize)
     def initialize(success, message, params = {}, options = {})
@@ -73,6 +73,7 @@ module ActiveShipping
       @shipper_address = options[:shipper_address]
       @origin = options[:origin]
       @destination = options[:destination]
+      @packages = options[:packages]
       super
     end
 
@@ -86,6 +87,10 @@ module ActiveShipping
     # @return [Boolean]
     def is_delivered?
       @status == :delivered
+    end
+
+    def all_delivered?
+      packages.all? { |package| package.is_delivered? }
     end
 
     # Returns `true` if something out of the ordinary has happened during


### PR DESCRIPTION
https://food52.atlassian.net/browse/FOOD52-3993

### Description
Since I basically just moved most of the logic into a loop, it may be beneficial to look at the code diff with the whitespace removal param: https://github.com/food52/active_shipping/pull/9/files?utf8=%E2%9C%93&diff=unified&w=1

Currently when UPS returns multiple packages for a single query we only parse data on the first one. This is fine when we were looking up Shipments via a tracking code however now we are expending into reference number lookups.

Reference numbers are added when the label is created (we have our vendors use `<order_id>-<shipment_id>`) and allow us to use data in our system to query UPS to see if specific shipments have been picked up.

With this iteration of ActiveShipping I created a new class `UpsTrackedPackage` - I store pretty much all of the same information that was passed to the `TrackingResponse` but for each specific package. `TrackResponse` is now populated by pulling that same data off the first pacakge. This allows legacy compatibility (looks at the first package and provides all the same data) however also allows the application to dig into specific package data.

This will let us lookup a Shipment by reference number which could have more than one label created for it. When we get this data back to the application we can split the shipments and automatically fulfill the VOF without the vendor having to upload a Shipment -> Tracking Number CSV!

### Testing
This should mostly be tested on the application side. For ActiveShipping specifics dig through the production DB for active tracking numbers, and ask Laura or myself for potential reference numbers. Verify legacy fields are still filled and additional package data is provided.

To test the gem specifically, I've found the easiest way is via IRB, run this inside the `active_shipping` repo folder
```
irb -I lib/ -r active_shipping
```