### PR TITLE
Protect against nil zip.

### DIFF
--- a/lib/active_shipping/carriers/stamps.rb
+++ b/lib/active_shipping/carriers/stamps.rb
@@ -305,8 +305,8 @@ module ActiveShipping
           xml['tns'].State(       address.state) unless address.state.blank?
 
           zip = (address.postal_code || '').match(/^(\d{5})?-?(\d{4})?$/)
-          xml['tns'].ZIPCode(     zip[1]) unless zip[1].nil?
-          xml['tns'].ZIPCodeAddOn(zip[2]) unless zip[2].nil?
+          xml['tns'].ZIPCode(     zip[1]) unless zip.nil? || zip[1].nil?
+          xml['tns'].ZIPCodeAddOn(zip[2]) unless zip.nil? || zip[2].nil?
         else
           xml['tns'].Province(    address.province) unless address.province.blank?
           xml['tns'].PostalCode(  address.postal_code) unless address.postal_code.blank?


### PR DESCRIPTION
https://food52.atlassian.net/browse/FOOD52-4264

When ordering via PayPal (and probably Apple Pay/Google Pay) it's possible to submit a shipping address with zip codes that don't follow the 12345-1234 format. 

The code in the stamps service regexes using the 12345-1234 format and then has logic to access the matched elements. There are nil checks on the array items, but a bigger issue is that if there are 0 matches then entire zip variable is nil causing a nilClass error.

This PR adds an additional nil check before trying to access the array elements.

Steps to duplicate:
[Before upgrading ActiveShipping]
- Add an item to your cart. When the quick cart opens, click the PayPal button instead of the Checkout button.
- In the PayPal modal, select the payment method and then change the shipping address.
- Enter a shipping address that contains an invalid zip code. A good example is a zip with a space instead of a -: 92030 3002.
- Place the order with PayPal and the invalid zip code.
- Go to the merchant admin for the order and attempt to fulfill the order using USPS as the carrier (you'll need to enable USPS if not already for that merchant).
- Verify a nilClass error appears.

[After Upgrading ActiveShipping]
- Try to fulfill the same order with USPS. 
- Verify a more meaningful error message appears saying the zip is not valid.

In a separate PR I'll update the admin to replace space with - to prevent this error from happening, but this change will at least prevent an unexpected nil error.
